### PR TITLE
fix: update secret templating to reuse when secret already exists

### DIFF
--- a/chart/templates/password-secret.yaml
+++ b/chart/templates/password-secret.yaml
@@ -1,11 +1,19 @@
-{{- $password := randAlphaNum 16 }}
+{{- $namespace := .Release.Namespace }}
+{{- $existingSecret := lookup "v1" "Secret" $namespace "valkey-password" }}
+{{- $password := (randAlphaNum 16) }}
+{{- if $existingSecret }}
+  {{- $decoded := index $existingSecret.data "valkey-password" | b64dec }}
+  {{- $password = $decoded }}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:
   name: valkey-password
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $namespace }}
 stringData:
-  valkey-password: {{ printf "%s" $password | quote }}
+  valkey-password: {{ $password | quote }}
+
 {{- if .Values.copyPassword.enabled }}
 ---
 apiVersion: v1
@@ -14,5 +22,6 @@ metadata:
   name: {{ .Values.copyPassword.secretName }}
   namespace: {{ .Values.copyPassword.namespace }}
 stringData:
-  {{ dict .Values.copyPassword.secretKey $password | toYaml }}
+  {{- $data := dict .Values.copyPassword.secretKey $password }}
+  {{- toYaml $data | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
## Description

update secret templating to reuse when secret already exists as chart does not support changing the secret after deployment

## Related Issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-valkey/blob/main/CONTRIBUTING.md#developer-workflow) followed
