### PR TITLE
draft: switched to fips version of unicorn flavor

### DIFF
--- a/values/unicorn-values.yaml
+++ b/values/unicorn-values.yaml
@@ -3,7 +3,7 @@
 
 image:
   registry: cgr.dev
-  repository: du-uds-defenseunicorns/valkey
+  repository: du-uds-defenseunicorns/valkey-fips
   tag: 8.0.2
 
 sentinel:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -35,6 +35,6 @@ components:
         valuesFiles:
           - ./values/unicorn-values.yaml
     images:
-      - cgr.dev/du-uds-defenseunicorns/valkey:8.0.2
+      - cgr.dev/du-uds-defenseunicorns/valkey-fips:8.0.2
       - cgr.dev/du-uds-defenseunicorns/prometheus-redis-exporter-bitnami:1.67.0
       - bitnami/valkey-sentinel:8.0.2-debian-12-r0


### PR DESCRIPTION
Notes from the initial review:

- There _can_ be problems when a FIPS-enabled component is used with non-FIPS components. Therefore, being FIPS by default could cause problems for someone later.
- This should be tested with prometheus to be sure the exporter is still working, this _has not been done yet_.
- The effort that requested FIPS here has delayed adoption of this package, therefore further work here won't be pursued at this time.