### PR TITLE
chore: add optional redis uri output

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -11,6 +11,8 @@ packages:
   - name: valkey
     path: ../
     ref: dev
+    optionalComponents:
+      - valkey-redis-uri-output
     overrides:
       valkey:
         uds-valkey-config:
@@ -47,8 +49,6 @@ packages:
   - name: valkey
     path: ../
     ref: dev
-    optionalComponents:
-      - valkey-redis-uri-output
     overrides:
       valkey:
         uds-valkey-config:

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -47,6 +47,8 @@ packages:
   - name: valkey
     path: ../
     ref: dev
+    optionalComponents:
+      - valkey-redis-uri-output
     overrides:
       valkey:
         uds-valkey-config:

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -15,8 +15,8 @@ components:
       onDeploy:
         after:
           - cmd: |
-              svc=$(kubectl get svc valkey-primary -n valkey --ignore-not-found 2>/dev/null | grep -q . && echo valkey-primary || echo valkey)
-              password=$(kubectl get secret valkey-password -n valkey -o go-template='{{index .data "valkey-password" | base64decode}}')
+              svc=$(./zarf tools kubectl get svc valkey-primary -n valkey --ignore-not-found 2>/dev/null | grep -q . && echo valkey-primary || echo valkey)
+              password=$(./zarf tools kubectl get secret valkey-password -n valkey -o go-template='{{index .data "valkey-password" | base64decode}}')
               printf 'redis://:%s@%s.valkey.svc.cluster.local:6379' "$password" "$svc"
             description: "Read Valkey password and set REDIS_URI"
             mute: true

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -8,6 +8,22 @@ metadata:
   url: https://github.com/valkey-io/valkey
 
 components:
+  - name: valkey-redis-uri-output
+    description: "Reads the Valkey password secret and sets REDIS_URI as a Zarf variable"
+    required: false
+    actions:
+      onDeploy:
+        after:
+          - cmd: |
+              svc=$(kubectl get svc valkey-primary -n valkey --ignore-not-found 2>/dev/null | grep -q . && echo valkey-primary || echo valkey)
+              password=$(kubectl get secret valkey-password -n valkey -o go-template='{{index .data "valkey-password" | base64decode}}')
+              printf 'redis://:%s@%s.valkey.svc.cluster.local:6379' "$password" "$svc"
+            description: "Read Valkey password and set REDIS_URI"
+            mute: true
+            setVariables:
+              - name: REDIS_URI
+                sensitive: true
+
   - name: valkey
     required: true
     charts:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,13 @@ Valkey is currently configured to expect a single user or workload to be using i
 - `copyPassword.secretName`: the name to give the Kubernetes secret in the other namespace
 - `copyPassword.secretKey`: the key to place the password under within the Kubernetes secret
 
+## Redis URI Output
+
+The optional `valkey-redis-uri-output` component sets a `REDIS_URI` Zarf variable by reading the `valkey-password` secret from the `valkey` namespace. It automatically detects whether the deployment is standalone or HA by checking for the presence of the `valkey-primary` service, and constructs the URI accordingly:
+
+- Standalone: `redis://:<password>@valkey-primary.valkey.svc.cluster.local:6379`
+- HA/Sentinel: `redis://:<password>@valkey.valkey.svc.cluster.local:6379`
+
 ## High Availability
 
 The default Valkey configuration is a single read/write node, which is sufficient for most use cases. For example, GitLab recommends a single-node architecture even in [their 2,000 user reference architecture](https://docs.gitlab.com/ee/administration/reference_architectures/2k_users.html). They only suggest replication starting with [their 3000 user reference architecture](https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html) (note that the pages linked refer to Redis, for which Valkey is a drop-in replacement). For scenarios requiring higher availability, this package also supports a replicated architecture.

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -44,3 +44,8 @@ components:
       - quay.io/rfcurated/valkey/valkey:8.1.6-jammy-fips-rfcurated
       - quay.io/rfcurated/redis-exporter:1.81.0-jammy-scratch-bnt-fips-rfcurated
       - quay.io/rfcurated/valkey-sentinel:8.1.6-jammy-bnt-fips-rfcurated
+
+  - name: valkey-redis-uri-output
+    required: false
+    import:
+      path: common


### PR DESCRIPTION
## Description

Adds an optional Zarf component intended to expose a REDIS_URI variable derived from the deployed Valkey instance’s Kubernetes secret/service.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/valkey/blob/main/CONTRIBUTING.md#developer-workflow) followed
