### PR TITLE
chore: swap rf images for cgr

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -87,12 +87,6 @@ packages:
               value: replication
             - path: sentinel.enabled  # https://github.com/bitnami/charts/blob/main/bitnami/valkey/values.yaml#L1143
               value: true
-            - path: sentinel.automateClusterRecovery
-              value: true
-            - path: sentinel.downAfterMilliseconds
-              value: 2000
-            - path: sentinel.failoverTimeout
-              value: 18000
           variables:
             - name: VALKEY_RESOURCES
               path: "primary.resources"

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -93,12 +93,6 @@ packages:
               value: 2000
             - path: sentinel.failoverTimeout
               value: 18000
-            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.enabled
-              value: true
-            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.whenScaled
-              value: Delete
-            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.whenDeleted
-              value: Delete
           variables:
             - name: VALKEY_RESOURCES
               path: "primary.resources"

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -93,6 +93,12 @@ packages:
               value: 2000
             - path: sentinel.failoverTimeout
               value: 18000
+            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.enabled
+              value: true
+            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.whenScaled
+              value: Delete
+            - path: sentinel.replica.persistentVolumeClaimRetentionPolicy.whenDeleted
+              value: Delete
           variables:
             - name: VALKEY_RESOURCES
               path: "primary.resources"

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -87,6 +87,12 @@ packages:
               value: replication
             - path: sentinel.enabled  # https://github.com/bitnami/charts/blob/main/bitnami/valkey/values.yaml#L1143
               value: true
+            - path: sentinel.automateClusterRecovery
+              value: true
+            - path: sentinel.downAfterMilliseconds
+              value: 2000
+            - path: sentinel.failoverTimeout
+              value: 18000
           variables:
             - name: VALKEY_RESOURCES
               path: "primary.resources"

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -6,5 +6,5 @@ flavors:
     # renovate-uds: datasource=docker depName=bitnamilegacy/valkey extractVersion=^(?<version>\d+\.\d+\.\d+)(-debian-.*)?$
     version: 8.1.3-uds.4
   - name: unicorn
-    # renovate-uds: datasource=docker depName=quay.io/rfcurated/valkey/valkey extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
-    version: 8.1.6-uds.2
+    # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/valkey-iamguarded extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
+    version: 8.1.7-uds.0

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -6,5 +6,5 @@ flavors:
     # renovate-uds: datasource=docker depName=bitnamilegacy/valkey extractVersion=^(?<version>\d+\.\d+\.\d+)(-debian-.*)?$
     version: 8.1.3-uds.4
   - name: unicorn
-    # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/valkey-iamguarded extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
+    # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/valkey-iamguarded extractVersion=^(?<version>\d+\.\d+\.\d+)?$
     version: 8.1.7-uds.0

--- a/tests/valkey/test-job.yaml
+++ b/tests/valkey/test-job.yaml
@@ -48,7 +48,7 @@ spec:
 
               echo "All checks passed."
       restartPolicy: OnFailure
-  backoffLimit: 5
+  backoffLimit: 15
 ---
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
@@ -147,4 +147,4 @@ spec:
 
               echo "All checks passed."
       restartPolicy: OnFailure
-  backoffLimit: 5
+  backoffLimit: 15

--- a/tests/valkey/test-job.yaml
+++ b/tests/valkey/test-job.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: valkey-test
 spec:
-  completions: 5
+  completions: 10
   parallelism: 1
   template:
     metadata:
@@ -59,7 +59,7 @@ metadata:
   labels:
     app: valkey-test
 spec:
-  completions: 5
+  completions: 10
   parallelism: 1
   template:
     metadata:
@@ -83,7 +83,7 @@ spec:
             - |
               SENTINEL_HOST="valkey.valkey-replicated-w-sentinel.svc.cluster.local"
               SENTINEL_PORT="26379"
-
+            
               # Wait for Sentinel to have quorum before trusting any topology answer it gives.
               # On fresh deploys or just after a failover, Sentinels need a few seconds to gossip
               # and agree on the primary. Without this, GET-PRIMARY-ADDR-BY-NAME can return a
@@ -108,16 +108,16 @@ spec:
 
                   HOST=$(echo "${PRIMARY_ADDR}" | sed -n '1p')
                   PORT=$(echo "${PRIMARY_ADDR}" | sed -n '2p')
-                  echo "Sentinel says primary is ${HOST}:${PORT}"
+                  echo "Primary is ${HOST}:${PORT}"
 
-                  # ROLE returns 'master' or 'slave' on the first line — ground truth from the node.
+                  # ROLE returns 'master' or 'slave'.
                   ROLE=$(echo "ROLE" | valkey-cli -h ${HOST} -p ${PORT} | head -n 1)
                   if [ "${ROLE}" = "master" ]; then
                       echo "Confirmed ${HOST}:${PORT} is primary."
                       break
                   fi
 
-                  echo "Attempt ${attempt}: ${HOST}:${PORT} reports role=${ROLE}, waiting for topology to settle..."
+                  echo "Attempt ${attempt}: ${HOST}:${PORT} reports role=${ROLE}"
                   HOST=""
                   sleep 3
               done
@@ -147,4 +147,4 @@ spec:
 
               echo "All checks passed."
       restartPolicy: OnFailure
-  backoffLimit: 15
+  backoffLimit: 5

--- a/tests/valkey/test-job.yaml
+++ b/tests/valkey/test-job.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: valkey-test
 spec:
-  completions: 10
+  completions: 5
   parallelism: 1
   template:
     metadata:
@@ -59,7 +59,7 @@ metadata:
   labels:
     app: valkey-test
 spec:
-  completions: 10
+  completions: 5
   parallelism: 1
   template:
     metadata:
@@ -81,14 +81,51 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              # Ask the Sentinel which node is the primary node. 'mymaster' is the default name of the primary node.
-              PRIMARY_ADDR="$(echo 'SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster' | valkey-cli -h valkey.valkey-replicated-w-sentinel.svc.cluster.local -p 26379)"
-              echo "Primary ADDR is: ${PRIMARY_ADDR}"
+              SENTINEL_HOST="valkey.valkey-replicated-w-sentinel.svc.cluster.local"
+              SENTINEL_PORT="26379"
 
-              # Extract HOST and PORT using sed
-              HOST=$(echo "${PRIMARY_ADDR}" | sed -n '1p')
-              PORT=$(echo "${PRIMARY_ADDR}" | sed -n '2p')
-              echo "Primary is ${HOST}:${PORT}"
+              # Wait for Sentinel to have quorum before trusting any topology answer it gives.
+              # On fresh deploys or just after a failover, Sentinels need a few seconds to gossip
+              # and agree on the primary. Without this, GET-PRIMARY-ADDR-BY-NAME can return a
+              # node that is actually a replica, and writes will fail with READONLY.
+              echo "Waiting for Sentinel quorum on mymaster..."
+              for attempt in 1 2 3 4 5 6 7 8 9 10; do
+                  if echo "SENTINEL CKQUORUM mymaster" | valkey-cli -h ${SENTINEL_HOST} -p ${SENTINEL_PORT} | grep -q OK; then
+                      echo "Sentinel quorum reached."
+                      break
+                  fi
+                  echo "Attempt ${attempt}: Sentinel quorum not ready, retrying..."
+                  sleep 3
+              done
+
+              # Ask Sentinel which node is the primary, then verify the node itself agrees.
+              # Retry the lookup if the node reports it is actually a replica (stale Sentinel view).
+              HOST=""
+              PORT=""
+              for attempt in 1 2 3 4 5; do
+                  PRIMARY_ADDR="$(echo 'SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster' | valkey-cli -h ${SENTINEL_HOST} -p ${SENTINEL_PORT})"
+                  echo "Primary ADDR is: ${PRIMARY_ADDR}"
+
+                  HOST=$(echo "${PRIMARY_ADDR}" | sed -n '1p')
+                  PORT=$(echo "${PRIMARY_ADDR}" | sed -n '2p')
+                  echo "Sentinel says primary is ${HOST}:${PORT}"
+
+                  # ROLE returns 'master' or 'slave' on the first line — ground truth from the node.
+                  ROLE=$(echo "ROLE" | valkey-cli -h ${HOST} -p ${PORT} | head -n 1)
+                  if [ "${ROLE}" = "master" ]; then
+                      echo "Confirmed ${HOST}:${PORT} is primary."
+                      break
+                  fi
+
+                  echo "Attempt ${attempt}: ${HOST}:${PORT} reports role=${ROLE}, waiting for topology to settle..."
+                  HOST=""
+                  sleep 3
+              done
+
+              if [ -z "${HOST}" ] || [ "${ROLE}" != "master" ]; then
+                  echo "Could not find a writable primary after retries. Last role seen: ${ROLE}"
+                  exit 1
+              fi
 
               # Check if primary responds to PING
               PING_OUTPUT=$(echo "ping" | valkey-cli -h ${HOST} -p ${PORT})
@@ -110,4 +147,4 @@ spec:
 
               echo "All checks passed."
       restartPolicy: OnFailure
-  backoffLimit: 5
+  backoffLimit: 15

--- a/tests/valkey/test-job.yaml
+++ b/tests/valkey/test-job.yaml
@@ -83,7 +83,7 @@ spec:
             - |
               SENTINEL_HOST="valkey.valkey-replicated-w-sentinel.svc.cluster.local"
               SENTINEL_PORT="26379"
-            
+
               # Wait for Sentinel to have quorum before trusting any topology answer it gives.
               # On fresh deploys or just after a failover, Sentinels need a few seconds to gossip
               # and agree on the primary. Without this, GET-PRIMARY-ADDR-BY-NAME can return a

--- a/tests/zarf.yaml
+++ b/tests/zarf.yaml
@@ -27,4 +27,4 @@ components:
         after:
           - description: Watch test jobs and report their conditions
             cmd: ./tests/watch-jobs.sh
-            maxTotalSeconds: 120
+            maxTotalSeconds: 300

--- a/values/unicorn-values.yaml
+++ b/values/unicorn-values.yaml
@@ -2,18 +2,18 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 image:
-  registry: quay.io
-  repository: rfcurated/valkey/valkey
-  tag: 8.1.6-jammy-fips-rfcurated
+  registry: cgr.dev
+  repository: defenseunicorns.com/valkey-iamguarded
+  tag: 8.1.7
 
 sentinel:
   image:  # Unicorn flavor option DNE
-    registry: quay.io
-    repository: rfcurated/valkey-sentinel
-    tag: 8.1.6-jammy-bnt-fips-rfcurated
+    registry: cgr.dev
+    repository: defenseunicorns.com/valkey-sentinel-iamguarded
+    tag: 8.1.7
 
 metrics:
   image:
-    registry: quay.io
-    repository: rfcurated/redis-exporter
-    tag: 1.82.0-jammy-scratch-bnt-fips-rfcurated
+    registry: cgr.dev
+    repository: defenseunicorns.com/prometheus-redis-exporter-iamguarded
+    tag: 1.83.0

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -12,3 +12,6 @@ metrics:
 
 sentinel:
   primarySet: mymaster
+  automateClusterRecovery: true
+  downAfterMilliseconds: 2000
+  failoverTimeout: 18000

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -41,9 +41,9 @@ components:
         valuesFiles:
           - ./values/unicorn-values.yaml
     images:
-      - quay.io/rfcurated/valkey/valkey:8.1.6-jammy-fips-rfcurated
-      - quay.io/rfcurated/redis-exporter:1.82.0-jammy-scratch-bnt-fips-rfcurated
-      - quay.io/rfcurated/valkey-sentinel:8.1.6-jammy-bnt-fips-rfcurated
+      - cgr.dev/defenseunicorns.com/valkey-iamguarded:8.1.7
+      - cgr.dev/defenseunicorns.com/prometheus-redis-exporter-iamguarded:1.83.0
+      - cgr.dev/defenseunicorns.com/valkey-sentinel-iamguarded:8.1.7
 
   - name: valkey-redis-uri-output
     required: false


### PR DESCRIPTION
## Description

- Update images from `rfcurated` -> `chainguard`
- While the test job was still starting up, it would fail before determining a `master` node and would return a `replica` node when it would require the `master` node. Hardened the testing to wait longer for Sentinel to determine the master node.
- Updated bundle config to help replicas discovery the primary at startup.

## Related Issue

Relates to # https://linear.app/defense-unicorns/issue/FDRY-99/update-valkey-package-for-chainguard-images

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/valkey/blob/main/CONTRIBUTING.md#developer-workflow) followed
