### PR TITLE
fix: add id-token perm for chainguard image pulling

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -12,6 +12,7 @@ permissions:
   contents: write # Allows writing content to the repository.
   packages: read # Allows reading the content of the repository's packages.
   pull-requests: write # Allows creating or updating pull requests.
+  id-token: write # Required by uds-common auto-update workflow to authenticate with chainguard
 
 # Abort prior jobs in the same workflow / PR
 concurrency:


### PR DESCRIPTION
## Description

Add id-token so auto update will work for chainguard images.

## Related Issue

Relates to # https://linear.app/defense-unicorns/issue/FDRY-106/add-id-token-to-auto-update-for-individual-repo-workflows

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] Contributor Guide Steps] followed
